### PR TITLE
Set global `safe.directory` setting

### DIFF
--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -25,7 +25,7 @@ jobs:
 
     - name: Push Tag to mirror
       id: push_to_mirror
-      uses: mysociety/action-git-pusher@v1.0.0
+      uses: mysociety/action-git-pusher@master
       with:
         git_ssh_key: ${{ secrets.PUBLICCVS_GIT_KEY }}
         ssh_known_hosts: ${{ secrets.GIT_KNOWN_HOSTS }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,6 +5,8 @@ set -e
 eval "$(ssh-agent)"
 ssh-add <(echo "$INPUT_GIT_SSH_KEY")
 
+git config --global --add safe.directory /github/workspace
+
 if [ -n "$INPUT_SSH_KNOWN_HOSTS" ] ; then
     echo "$INPUT_SSH_KNOWN_HOSTS" > /known_hosts
     git config --global core.sshCommand "ssh -o UserKnownHostsFile=/known_hosts -o CheckHostIP=no"


### PR DESCRIPTION
Debian Buster recently backported in patches for CVE-2022-24765 which can cause problems if parent directories are owned by a user different to the one working with Git. Setting `safe.directory` to `/github/workspace` disables this and should be safe in this context.