### PR TITLE
Extra git config

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ jobs:
 
     - name: Push Tag to mirror
       id: push_to_mirror
-      uses: mysociety/action-git-pusher@v1.0.0
+      uses: mysociety/action-git-pusher@v1.2.0
       with:
         git_ssh_key: ${{ secrets.SOME_GIT_KEY }}
         ssh_known_hosts: ${{ secrets.SOME_KNOWN_HOSTS }}
@@ -53,7 +53,7 @@ To add extra flags to the git push command, you can use the `extra_git_config` i
 ```yaml
     - name: Test force pushing to mirror
       id: push_to_mirror
-      uses: mysociety/action-git-pusher@v1.0.0
+      uses: mysociety/action-git-pusher@v1.2.0
       with:
         git_ssh_key: ${{ secrets.SOME_GIT_KEY }}
         ssh_known_hosts: ${{ secrets.SOME_KNOWN_HOSTS }}

--- a/README.md
+++ b/README.md
@@ -47,3 +47,17 @@ jobs:
         tag: ${{ steps.bump_tag.outputs.new_tag }}
         remote: 'ssh://username@git.example.com/path/to/repository.git'
 ```
+
+To add extra flags to the git push command, you can use the `extra_git_config` input.
+
+```yaml
+    - name: Test force pushing to mirror
+      id: push_to_mirror
+      uses: mysociety/action-git-pusher@v1.0.0
+      with:
+        git_ssh_key: ${{ secrets.SOME_GIT_KEY }}
+        ssh_known_hosts: ${{ secrets.SOME_KNOWN_HOSTS }}
+        tag: ${{ steps.bump_tag.outputs.new_tag }}
+        remote: 'ssh://username@git.example.com/path/to/repository.git'
+        extra_git_config: --force --dry-run
+```

--- a/action.yaml
+++ b/action.yaml
@@ -13,6 +13,10 @@ inputs:
   tag:
     description: 'If you just want to push a tag, provide it here.'
     required: false
+  extra_git_config:
+    description: 'Any extra config to fit to the git push comment (e.g. --force)'
+    required: false
+    default: ''
 runs:
   using: docker
   image: 'Dockerfile'

--- a/action.yaml
+++ b/action.yaml
@@ -14,7 +14,7 @@ inputs:
     description: 'If you just want to push a tag, provide it here.'
     required: false
   extra_git_config:
-    description: 'Any extra config to fit to the git push comment (e.g. --force)'
+    description: 'Any extra config for the git push comment (e.g. --force)'
     required: false
     default: ''
 runs:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -16,8 +16,11 @@ fi
 
 git remote add mirror "$INPUT_REMOTE"
 
+# Extract potentially multiple flags to CONFIG_FLAGS
+IFS=' ' read -ra CONFIG_FLAGS <<< "$INPUT_EXTRA_GIT_CONFIG"
+
 if [ -n "$INPUT_TAG" ] ; then
-    git push mirror "$INPUT_TAG" $INPUT_EXTRA_GIT_CONFIG
+    git push mirror "$INPUT_TAG" "${CONFIG_FLAGS[@]}"
 else
     echo "Not implemented yet"
     exit 1

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -17,7 +17,7 @@ fi
 git remote add mirror "$INPUT_REMOTE"
 
 if [ -n "$INPUT_TAG" ] ; then
-    git push mirror "$INPUT_TAG"
+    git push mirror "$INPUT_TAG" $INPUT_EXTRA_GIT_CONFIG
 else
     echo "Not implemented yet"
     exit 1


### PR DESCRIPTION
Adds an extra config option.

This allows github actions that can force push back to git.mysociety.org. Means history can be rewritten through a github only workflow. 

e.g. https://github.com/mysociety/twfy-votes/blob/main/.github/workflows/mirror_manual.yml