### PR TITLE
Switch base image to bookworm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster-slim
+FROM debian:bookworm-slim
 
 LABEL maintainer="mySociety <sysadmin@mysociety.org>"
 


### PR DESCRIPTION
This action is getting errors because buster things are being deprecated:

3.302 E: The repository 'http://deb.debian.org/debian buster Release' does not have a Release file.
3.302 E: The repository 'http://deb.debian.org/debian-security buster/updates Release' does not have a Release file.
3.302 E: The repository 'http://deb.debian.org/debian buster-updates Release' does not have a Release file.

I've updated the base image to bookworm-slim

I've tested it here: all seems well: https://github.com/mysociety/parlparse/actions/runs/16261951759/job/45908971853?pr=229

Annoyingly we'll have to update the action version in a few places. 